### PR TITLE
Don't silence test reporter messages on test timeout

### DIFF
--- a/doc/interpreting_errors.md
+++ b/doc/interpreting_errors.md
@@ -67,8 +67,6 @@ Tests that take too long to run are terminated by Overman and are reported as te
 
 Tests that time out will be reported as such. Additionally, Overman will say in which phase of the test it was when the test timed out (in a hook or in the test).
 
-When tests time out, after hooks are run, but no further reporting is done. This is done in order to let reporters live in the illusion that when tests time out, that's the last thing that happened to the test.
-
 ```javascript
 it('should loop infinitely', function() {
   for (;;);

--- a/doc/reporter_api.md
+++ b/doc/reporter_api.md
@@ -223,6 +223,18 @@ before hook has failed. It means that the test runner is about to execute the
 after hooks. This message is emitted even when there are not after hooks. This
 message is *not* emitted when the test timed out before this stage.
 
+### timeout
+
+```javascript
+{
+  "type": "timeout"
+}
+```
+
+When a test times out, this message is emitted. It is not necessary to listen to
+this message in order to determine if a test timed out or not. When a test times
+out there is always also a `finish` message with `result` `timeout`.
+
 ### finish
 
 ```javascript

--- a/lib/suite_runner.js
+++ b/lib/suite_runner.js
@@ -92,16 +92,7 @@ function runTest(softKill, timeoutTimer, childProcess, timeout, graceTime, slowT
   var didTimeout = false;
   var child = runTestProcess(childProcess, timeout, slowThreshold, reporter, testInterfacePath, testInterfaceParameter, testPath);
 
-  child.on('message', function(message) {
-    if (!didTimeout) {
-      // In order to provide a coherent message stream to the reporter, all
-      // messages from the test process after a timeout are suppressed.
-      // Otherwise there is a chance that messages are emitted after the
-      // { type: 'finish', result: 'timeout' } message, which is supposed to be
-      // the very last message for that test.
-      reporter.gotMessage(testPath, message);
-    }
-  });
+  child.on('message', reporter.gotMessage.bind(reporter, testPath));
 
   if (timeout !== 0) {
     killAfter(softKill, timeoutTimer, child, timeout, graceTime, function() {

--- a/lib/suite_runner.js
+++ b/lib/suite_runner.js
@@ -107,7 +107,6 @@ function runTest(softKill, timeoutTimer, childProcess, timeout, graceTime, slowT
     killAfter(softKill, timeoutTimer, child, timeout, graceTime, function() {
       didTimeout = true;
       reporter.gotMessage(testPath, { type: 'timeout' });
-      reporter.gotMessage(testPath, { type: 'finish', result: 'timeout' });
     });
   }
 
@@ -125,9 +124,7 @@ function runTest(softKill, timeoutTimer, childProcess, timeout, graceTime, slowT
       closePromise
         .done(function() {
           if (didTimeout) {
-            // By now we have already sent a non-success finish message, so we
-            // must make sure to reject the promise, otherwise the test won't be
-            // retried.
+            reporter.gotMessage(testPath, { type: 'finish', result: 'timeout' });
             reject(new Error('Test timed out'));
           } else {
             reporter.gotMessage(testPath, {

--- a/lib/suite_runner.js
+++ b/lib/suite_runner.js
@@ -106,6 +106,7 @@ function runTest(softKill, timeoutTimer, childProcess, timeout, graceTime, slowT
   if (timeout !== 0) {
     killAfter(softKill, timeoutTimer, child, timeout, graceTime, function() {
       didTimeout = true;
+      reporter.gotMessage(testPath, { type: 'timeout' });
       reporter.gotMessage(testPath, { type: 'finish', result: 'timeout' });
     });
   }

--- a/test/suite/suite_single_test_that_never_finishes_with_after_hook.js
+++ b/test/suite/suite_single_test_that_never_finishes_with_after_hook.js
@@ -23,5 +23,6 @@ it('should never finish', function() {
 });
 
 after(function() {
+  this.debugInfo('in', 'afterHook');
   console.log('in_after_hook');
 });

--- a/test/test_reporter_api.js
+++ b/test/test_reporter_api.js
@@ -310,17 +310,37 @@ describe('Reporter API', function() {
     }]);
   });
 
-  it('should emit timeout message for test that times out', function() {
-    return ensureMessages('suite_single_test_that_never_finishes', [function(testPath, message) {
-      expect(message).property('type').to.be.equal('timeout');
-    }]);
-  });
+  describe('Timeouts', function() {
+    it('should emit timeout message for test that times out', function() {
+      return ensureMessages('suite_single_test_that_never_finishes', [function(testPath, message) {
+        expect(message).property('type').to.be.equal('timeout');
+      }]);
+    });
 
-  it('should emit finish message for test that times out', function() {
-    return ensureMessages('suite_single_test_that_never_finishes', [function(testPath, message) {
-      expect(message).property('type').to.be.equal('finish');
-      expect(message).property('result').to.be.equal('timeout');
-    }]);
+    it('should emit finish message for test that times out', function() {
+      return ensureMessages('suite_single_test_that_never_finishes', [function(testPath, message) {
+        expect(message).property('type').to.be.equal('finish');
+        expect(message).property('result').to.be.equal('timeout');
+      }]);
+    });
+
+    it('should emit reporter messages even after the test times out', function() {
+      return ensureMessages('suite_single_test_that_never_finishes_with_after_hook', [function(testPath, message) {
+        expect(message).property('type').to.be.equal('debugInfo');
+        expect(message).property('name').to.be.equal('in');
+        expect(message).property('value').to.be.equal('afterHook');
+      }]);
+    });
+
+    it('should emit messages in the right order when test times out', function() {
+      return ensureMessages('suite_single_test_that_never_finishes_with_after_hook', [function(testPath, message) {
+        expect(message).property('type').to.be.equal('timeout');
+      }, function(testPath, message) {
+        expect(message).property('type').to.be.equal('debugInfo');
+      }, function(testPath, message) {
+        expect(message).property('type').to.be.equal('finish');
+      }]);
+    });
   });
 
   it('should emit only start and finish message for skipped test', function() {

--- a/test/test_reporter_api.js
+++ b/test/test_reporter_api.js
@@ -310,6 +310,12 @@ describe('Reporter API', function() {
     }]);
   });
 
+  it('should emit timeout message for test that times out', function() {
+    return ensureMessages('suite_single_test_that_never_finishes', [function(testPath, message) {
+      expect(message).property('type').to.be.equal('timeout');
+    }]);
+  });
+
   it('should emit finish message for test that times out', function() {
     return ensureMessages('suite_single_test_that_never_finishes', [function(testPath, message) {
       expect(message).property('type').to.be.equal('finish');


### PR DESCRIPTION
It discards potentially useful information and is also counterintuitive. The design choice made sense back when nothing but killing happened on timeout but now that after hooks are run it's not good anymore.