### PR TITLE
Fix problem with phase reporting in the spec reporter

### DIFF
--- a/lib/reporters/phase_tracker.js
+++ b/lib/reporters/phase_tracker.js
@@ -29,20 +29,28 @@
  */
 function PhaseTracker() {
   this._lastPhase = {};  // Hash of JSON'd testPath to { in: '', inName: '' }
+  this._timedOut = {};  // Hash of JSON'd testPath to true, if the test has timed out
 }
 module.exports = PhaseTracker;
 
 PhaseTracker.prototype.gotMessage = function(testPath, message) {
   var key = JSON.stringify(testPath);
 
-  if (message.type === 'startedBeforeHook') {
+  if (message.type === 'retry') {
+    delete this._lastPhase[key];
+    delete this._timedOut[key];
+  } else if (message.type === 'timeout') {
+    this._timedOut[key] = true;
+  } else if (this._timedOut[key]) {
+    // Do nothing; if the test timed out, we don't want to store any more.
+    // Otherwise we will always report that the test timed out in after
+    // hooks, even though that might not be the case.
+  } else if (message.type === 'startedBeforeHook') {
     this._lastPhase[key] = { in: 'beforeHook', inName: message.name };
   } else if (message.type === 'startedTest') {
     this._lastPhase[key] = { in: 'test' };
   } else if (message.type === 'startedAfterHook') {
     this._lastPhase[key] = { in: 'afterHook', inName: message.name };
-  } else if (message.type === 'retry') {
-    delete this._lastPhase[key];
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "overman",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Test runner for integration tests",
   "main": "lib/overman.js",
   "scripts": {

--- a/test/test_phase_tracker.js
+++ b/test/test_phase_tracker.js
@@ -61,4 +61,19 @@ describe('PhaseTracker', function() {
     tracker.gotMessage({ test: 'path' }, { type: 'retry' });
     expect(tracker.getLastPhase({ test: 'path' })).to.not.exist;
   });
+
+  it('should ignore phases after timeout', function() {
+    tracker.gotMessage({ test: 'path' }, { type: 'startedBeforeHook', name: 'The hook 1' });
+    tracker.gotMessage({ test: 'path' }, { type: 'timeout' });
+    tracker.gotMessage({ test: 'path' }, { type: 'startedAfterHook', name: 'The hook 2' });
+    expect(tracker.getLastPhase({ test: 'path' })).to.be.deep.equal({ in: 'beforeHook', inName: 'The hook 1' });
+  });
+
+  it('should start saving phases again after retries even if the previous attempt timed out', function() {
+    tracker.gotMessage({ test: 'path' }, { type: 'startedBeforeHook', name: 'The hook 1' });
+    tracker.gotMessage({ test: 'path' }, { type: 'timeout' });
+    tracker.gotMessage({ test: 'path' }, { type: 'retry' });
+    tracker.gotMessage({ test: 'path' }, { type: 'startedAfterHook', name: 'The hook 2' });
+    expect(tracker.getLastPhase({ test: 'path' })).to.be.deep.equal({ in: 'afterHook', inName: 'The hook 2' });
+  });
 });


### PR DESCRIPTION
It would report the wrong phase on timeouts when after hooks are present.