### PR TITLE
Fix teamcity reporter retry handling

### DIFF
--- a/lib/reporters/teamcity.js
+++ b/lib/reporters/teamcity.js
@@ -33,6 +33,7 @@ teamcityServiceMessages.stdout = false;  // Global yuck :-(
 function Teamcity(stream) {
   this._stream = stream;
   this._emittedErrorForTest = {};  // Keys are JSON testPath, value is true if an error has been emitted for that test
+  this._bufferedOutput = {};  // Keys are JSON testPath, value is output for the test
 }
 
 Teamcity.prototype.registrationFailed = function(error) {
@@ -49,27 +50,46 @@ Teamcity.prototype._write = function(string) {
   this._stream.write(string + '\n');
 };
 
+Teamcity.prototype._bufferTestOutput = function(testPath, string) {
+  var key = JSON.stringify(testPath);
+  if (!(key in this._bufferTestOutput)) {
+    this._bufferTestOutput[key] = '';
+  }
+  this._bufferTestOutput[key] += string + '\n';
+};
+
+Teamcity.prototype._writeBufferedOutput = function(testPath) {
+  var key = JSON.stringify(testPath);
+  this._stream.write(this._bufferTestOutput[key]);
+};
+
+Teamcity.prototype._clearBufferedOutput = function(testPath) {
+  var key = JSON.stringify(testPath);
+  this._bufferTestOutput[key] = '';
+};
+
 Teamcity.prototype._emitErrorForTest = function(testPath, args) {
   // According to the TC spec, only one testFailed should be emitted per test
   var key = JSON.stringify(testPath);
   if (!this._emittedErrorForTest[key]) {
     this._emittedErrorForTest[key] = true;
-    this._write(teamcityServiceMessages.testFailed(args));
+    this._bufferTestOutput(testPath, teamcityServiceMessages.testFailed(args));
   }
 };
 
 Teamcity.prototype.gotMessage = function(testPath, message) {
   var testName = testPath && _.last(testPath.path);
   var suiteName = message.suite && message.suite.path.join(' ');
+
   if (message.type === 'stdout') {
     // ##teamcity[testStdOut name='testname' out='text']
-    this._write(teamcityServiceMessages.testStdOut({
+    this._bufferTestOutput(testPath, teamcityServiceMessages.testStdOut({
       name: testName,
       out: message.data
     }));
   } else if (message.type === 'stderr') {
     // ##teamcity[testStdErr name='testname' out='error text']
-    this._write(teamcityServiceMessages.testStdErr({
+    this._bufferTestOutput(testPath, teamcityServiceMessages.testStdErr({
       name: testName,
       out: message.data
     }));
@@ -104,13 +124,15 @@ Teamcity.prototype.gotMessage = function(testPath, message) {
     }
 
     this._emitErrorForTest(testPath, errorMessage);
-  } else if (message.type === 'start') {
+  } else if (message.type === 'start' || message.type === 'retry') {
+    this._clearBufferedOutput(testPath);
+
     // for skipped tests: ##teamcity[testIgnored name='testname' message='ignore comment']
     // for other tests: ##teamcity[testStarted name='testname']
     if (message.skipped) {
-      this._write(teamcityServiceMessages.testIgnored({ name: testName }));
+      this._bufferTestOutput(testPath, teamcityServiceMessages.testIgnored({ name: testName }));
     } else {
-      this._write(teamcityServiceMessages.testStarted({ name: testName }));
+      this._bufferTestOutput(testPath, teamcityServiceMessages.testStarted({ name: testName }));
     }
   } else if (message.type === 'finish') {
     if (message.result === 'aborted') {
@@ -127,8 +149,10 @@ Teamcity.prototype.gotMessage = function(testPath, message) {
       if ('duration' in message) {
         _.extend(finishedMsg, { duration: message.duration });
       }
-      this._write(teamcityServiceMessages.testFinished(finishedMsg));
+      this._bufferTestOutput(testPath, teamcityServiceMessages.testFinished(finishedMsg));
     }
+
+    this._writeBufferedOutput(testPath);
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "overman",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Test runner for integration tests",
   "main": "lib/overman.js",
   "scripts": {


### PR DESCRIPTION
Previously the code completely ignored retries, meaning that if any of the runs failed, all of them did.