### PR TITLE
Report test timeouts the way TeamCity wants them

### DIFF
--- a/lib/reporters/teamcity.js
+++ b/lib/reporters/teamcity.js
@@ -106,7 +106,7 @@ Teamcity.prototype.gotMessage = function(testPath, message) {
     }
   } else if (message.type === 'timeout') {
     // ##teamcity[testFailed name='test1' message='Test timed out' details='message and stack trace']
-    this._emitErrorForTest(testPath, 'Test timed out');
+    this._emitErrorForTest(testPath, { name: testName, message: 'Test timed out' });
   } else if (message.type === 'error') {
     // possibly: ##teamcity[testFailed name='test1' message='failure message' details='message and stack trace']
     // possibly: ##teamcity[testFailed type='comparisonFailure' name='test2' message='failure message' details='message and stack trace' expected='expected value' actual='actual value']

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "overman",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Test runner for integration tests",
   "main": "lib/overman.js",
   "scripts": {

--- a/test/test_teamcity.js
+++ b/test/test_teamcity.js
@@ -255,7 +255,7 @@ describe('TeamCity reporter', function() {
         reporter.gotMessage(path, { type: 'finish', result: 'failure' });
       }, [
         /testStarted/,
-        /##teamcity\[testFailed 'Test timed out']/,
+        /##teamcity\[testFailed name='test1' message='Test timed out' flowId='\d+' timestamp='....-..-..T..:..:..\....'\]/,
         /testFinished/
       ]);
     });
@@ -368,7 +368,7 @@ describe('TeamCity reporter', function() {
         reporter.gotMessage(path, { type: 'finish', result: 'timeout' });
       }, [
         /testStarted/,
-        /##teamcity\[testFailed 'Test timed out']/,
+        /##teamcity\[testFailed name='test1' message='Test timed out' flowId='\d+' timestamp='....-..-..T..:..:..\....'\]/,
         /##teamcity\[testFinished name='test1' flowId='\d+' timestamp='....-..-..T..:..:..\....'\]/
       ]);
     });


### PR DESCRIPTION
Before this patch, TeamCity would ignore errors like this