### PR TITLE
Process test_run was not killed

### DIFF
--- a/lib/suite_runner.js
+++ b/lib/suite_runner.js
@@ -92,8 +92,11 @@ function runTestProcess(childProcess, debugPort, timeout, slowThreshold, reporte
     [testInterfacePath, JSON.stringify(parameters), testPath.file].concat(testPath.path),
     { silent: true, execArgv: process.execArgv.concat(debugArgs) });
 
-  hookStream(testPath, child.stdout, reporter, 'stdout');
-  hookStream(testPath, child.stderr, reporter, 'stderr');
+  // might be null in case of listening for debugger
+  if (child.stdout && child.stderr) {
+    hookStream(testPath, child.stdout, reporter, 'stdout');
+    hookStream(testPath, child.stderr, reporter, 'stderr');
+  }
 
   return child;
 }

--- a/test/test_suite_runner.js
+++ b/test/test_suite_runner.js
@@ -628,19 +628,18 @@ describe('Suite runner', function() {
 
   describe('Debug', function() {
     it('should run only one test when debugPort is specified', function() {
-      var tests = new Promise(function(resolve) {
-        runTestSuite('suite_two_passing_tests', [], {
-          reporters: [{
-            registerTests: function(tests) {
-              resolve(tests);
-            }
-          }],
-          debugPort: 1234
-        }).then(function() {}, function() {});
-      });
+      var suiteTests = [];
+      var tests = runTestSuite('suite_two_passing_tests', [], {
+        reporters: [{
+          registerTests: function(tests) {
+            suiteTests = tests;
+          }
+        }],
+        debugPort: 1234
+      }).then(function() {}, function() {});
 
-      return tests.then(function(tests) {
-        expect(tests.length).to.be.equal(1);
+      return tests.then(function() {
+        expect(suiteTests.length).to.be.equal(1);
       });
     });
 


### PR DESCRIPTION
The test did not wait for overman to finish, which lead to the
process child being kept alive.