### PR TITLE
Stabilise the subprocess tests

### DIFF
--- a/test/suite/suite_single_test_that_never_finishes_and_spawns_never_ending_processes.js
+++ b/test/suite/suite_single_test_that_never_finishes_and_spawns_never_ending_processes.js
@@ -19,11 +19,10 @@
 
 var childProcess = require('child_process');
 
-beforeEach(function() {
-  childProcess.fork(__dirname + '/../util/never_ending_program_that_may_fork_subprocess.js', ['fork']);
-  return new Promise(function(resolve) { setTimeout(function() { resolve(); }, 500); });
-});
-
 it('should spawn child processes and never finish', function() {
+  var child = childProcess.fork(__dirname + '/../util/never_ending_program_that_may_fork_subprocess.js', ['fork']);
+  child.on('message', function(data) {
+    process.send(data);
+  });
   return new Promise(function() {});
 });

--- a/test/suite/suite_single_test_that_spawns_never_ending_processes.js
+++ b/test/suite/suite_single_test_that_spawns_never_ending_processes.js
@@ -19,12 +19,15 @@
 
 var childProcess = require('child_process');
 
-beforeEach(function() {
-  childProcess.fork(__dirname + '/../util/never_ending_program_that_may_fork_subprocess.js', ['fork']);
-});
-
 it('should spawn child processes', function() {
-  // Have a small timeout to make sure the two child processes have started
-  // Might casue instability and need to be increased
-  return new Promise(function(resolve) { setTimeout(function() { resolve(); }, 250); });
+  return new Promise(function(resolve) {
+  var proc = childProcess.fork(__dirname + '/../util/never_ending_program_that_may_fork_subprocess.js', ['fork']);
+
+  process.on('message', function(data) {
+    (data.state === 'killme') && resolve();
+  });
+  proc.on('message', function(data) {
+    process.send(data);
+  });
+  });
 });

--- a/test/util/never_ending_program_that_may_fork_subprocess.js
+++ b/test/util/never_ending_program_that_may_fork_subprocess.js
@@ -1,5 +1,12 @@
 if (process.argv[2] === 'fork') {
-  require('child_process').fork(__dirname + '/../util/never_ending_program_that_may_fork_subprocess.js', ['empty']);
+  proc = require('child_process').fork(__dirname + '/../util/never_ending_program_that_may_fork_subprocess.js', ['empty']);
+  // Forward messages from fork
+  proc.on('message', function(data) {
+    process.send(data);
+  });
+} else {
+  // Send a message that forking is done
+  process.send({ state: 'forked' });
 }
 
 setInterval(function() {}, 1000);


### PR DESCRIPTION
Synchronise the process management but skipping the exiting part since we are killing them
the hard way, not getting triggers. Also making sure that the we have two processes
related to node, since we will also sometimes get for listing processes.