### PR TITLE
Node has builtin support for debugging

### DIFF
--- a/doc/suite_runner_api.md
+++ b/doc/suite_runner_api.md
@@ -55,9 +55,6 @@ runner:
 * `debugPort`: Enable debugging. This causes Overman to run only one test (the
   first one) and configure the test process for debugging at the specified port.
   This will often be used together with the `debuggerPort` option.
-* `inspectorPort`: Open a `node-inspector` server that can be used for debugging
-  a test in a browser. The specified port will be used by the `node-inspector`
-  web server. Requires the `debugPort` option to be set.
 * `internalErrorOutput`: When the suite runner fails with an internal error, it
   writes information about it to this stream. Defaults to stderr
 * `killSubProcesses`: If true, then overman will kill all subprocesses spawned by

--- a/lib/suite_runner.js
+++ b/lib/suite_runner.js
@@ -45,31 +45,6 @@ function reportSkippedTest(reporter, testPath) {
   reporter.gotMessage(testPath, { type: 'finish', result: 'skipped' });
 }
 
-function runDebugger(childProcess, debugPort, inspectorPort) {
-  var inspector = childProcess.fork(
-    require.resolve('node-inspector/bin/inspector'),
-    ['--debug-port=' + debugPort, '--web-port=' + inspectorPort]);
-
-  inspector.on('message', function(msg) {
-    if (msg.event === 'SERVER.ERROR') {
-      console.error('Cannot start the debugging server:', msg.error.code);
-    } else if (msg.event === 'SERVER.LISTENING') {
-      var version = process.versions.node.split('.');
-      if (version[0] === 6 && version[1] >= 4 || version[0] > 6) {
-        console.log('\x1b[31mWARNING: Node 6.4 -> 6.8 is not yet supported when debugging, please downgrade\x1b[0m');
-      }
-      console.log(
-        'Running node-inspector at',
-        msg.address.url,
-        '\n(if you already have this URL opened, it is sufficient to refresh that page)');
-    }
-  });
-
-  process.on('exit', function() {
-    inspector.kill();
-  });
-}
-
 function hookStream(testPath, stream, reporter, type) {
   stream.on('data', function(data) {
     reporter.gotMessage(testPath, {
@@ -87,7 +62,7 @@ function runTestProcess(childProcess, debugPort, timeout, slowThreshold, reporte
     interfaceParameter: testInterfaceParameter,
     killSubProcesses : killSubProcesses
   };
-  var debugArgs = debugPort ? ['--debug-brk=' + debugPort] : [];
+  var debugArgs = debugPort ? ['--debug-brk=' + debugPort, '--inspect=' + debugPort] : [];
   var child = childProcess.fork(
     __dirname + '/bin/run_test',
     [testInterfacePath, JSON.stringify(parameters), testPath.file].concat(testPath.path),
@@ -330,15 +305,6 @@ module.exports = function(options) {
     .then(function(tests) {
       if (options.debugPort) {
         tests = tests.slice(0, 1);  // Only run one test when debugging
-      }
-      if (options.inspectorPort) {
-        if (!options.debugPort) {
-          throw new TestFailureError('inspectorPort specified without debugPort');
-        }
-        runDebugger(
-            options.childProcess || childProcess,
-            options.debugPort,
-            options.inspectorPort);
       }
 
       if (reporter.registerTests) {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "exit": "~0.1.2",
     "is-running": "~2.1.0",
     "lodash": "~4.11.1",
-    "node-inspector": "^0.12.8",
     "ps-tree": "^1.1.0",
     "teamcity-service-messages": "~0.1.7",
     "through": "~2.3.8"

--- a/test/test_suite_runner.js
+++ b/test/test_suite_runner.js
@@ -692,15 +692,6 @@ describe('Suite runner', function() {
       });
     });
 
-    it('should require debugPort when inspectorPort is set', function() {
-      return shouldFail(runTestSuite('suite_single_successful_test', [], {
-        inspectorPort: 1234
-      }), function(error) {
-        return isTestFailureError(error) &&
-          error.message.match(/inspectorPort specified without debugPort/);
-      });
-    });
-
     function extractSubprocessForkOptions(options) {
       return new Promise(function(resolve, reject) {
         var mockChildProcess = {
@@ -717,7 +708,7 @@ describe('Suite runner', function() {
     it('should pass debug option to test subprocess', function() {
       return extractSubprocessForkOptions({ debugPort: 1234 })
         .then(function(options) {
-          expect(options).property('execArgv').to.be.deep.equal(['--debug-brk=1234']);
+          expect(options).property('execArgv').to.be.deep.equal(['--debug-brk=1234', '--inspect=1234']);
         });
     });
 
@@ -726,32 +717,6 @@ describe('Suite runner', function() {
         .then(function(options) {
           expect(options).property('execArgv').to.be.deep.equal([]);
         });
-    });
-
-    it('should start node-inspector subprocess', function() {
-      return new Promise(function(resolve, reject) {
-        var mockChildProcess = {
-          fork: function(path, args, options) {
-            if (path.match(/run_test/)) {
-              return childProcess.fork(path, args, options);
-            } else {
-              try {
-                expect(path).to.match(/bin\/inspector.js/);
-                expect(args).to.be.deep.equal(['--debug-port=1234', '--web-port=1235']);
-                resolve();
-              } catch (err) {
-                reject(err);
-              }
-            }
-          }
-        };
-        runTestSuite('suite_single_successful_test', [], {
-            childProcess: mockChildProcess,
-            debugPort: 1234,
-            inspectorPort: 1235
-          })
-          .then(function() {}, reject);
-      });
     });
   });
   describe('Members in currentTest', function() {


### PR DESCRIPTION
Node-inspector is not supported anymore and will not work with
node 6.3 and later.